### PR TITLE
fix: use LSPAny instead of serde_json::Value in public api

### DIFF
--- a/examples/custom_notification.rs
+++ b/examples/custom_notification.rs
@@ -1,5 +1,4 @@
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 use tower_lsp::jsonrpc::{Error, Result};
 use tower_lsp::lsp_types::notification::Notification;
 use tower_lsp::lsp_types::*;
@@ -53,7 +52,7 @@ impl LanguageServer for Backend {
         Ok(())
     }
 
-    async fn execute_command(&self, params: ExecuteCommandParams) -> Result<Option<Value>> {
+    async fn execute_command(&self, params: ExecuteCommandParams) -> Result<Option<LSPAny>> {
         if params.command == "custom.notification" {
             self.client
                 .send_notification::<CustomNotification>(CustomNotificationParams::new(

--- a/examples/stdio.rs
+++ b/examples/stdio.rs
@@ -1,4 +1,3 @@
-use serde_json::Value;
 use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::*;
 use tower_lsp::{Client, LanguageServer, LspService, Server};
@@ -69,7 +68,7 @@ impl LanguageServer for Backend {
             .await;
     }
 
-    async fn execute_command(&self, _: ExecuteCommandParams) -> Result<Option<Value>> {
+    async fn execute_command(&self, _: ExecuteCommandParams) -> Result<Option<LSPAny>> {
         self.client
             .log_message(MessageType::INFO, "command executed!")
             .await;

--- a/examples/tcp.rs
+++ b/examples/tcp.rs
@@ -1,4 +1,3 @@
-use serde_json::Value;
 use tokio::net::{TcpListener, TcpStream};
 use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::*;
@@ -70,7 +69,7 @@ impl LanguageServer for Backend {
             .await;
     }
 
-    async fn execute_command(&self, _: ExecuteCommandParams) -> Result<Option<Value>> {
+    async fn execute_command(&self, _: ExecuteCommandParams) -> Result<Option<LSPAny>> {
         self.client
             .log_message(MessageType::INFO, "command executed!")
             .await;

--- a/examples/websocket.rs
+++ b/examples/websocket.rs
@@ -1,5 +1,4 @@
 use async_tungstenite::tokio::accept_async;
-use serde_json::Value;
 use tokio::net::TcpListener;
 use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::*;
@@ -71,7 +70,7 @@ impl LanguageServer for Backend {
             .await;
     }
 
-    async fn execute_command(&self, _: ExecuteCommandParams) -> Result<Option<Value>> {
+    async fn execute_command(&self, _: ExecuteCommandParams) -> Result<Option<LSPAny>> {
         self.client
             .log_message(MessageType::INFO, "command executed!")
             .await;

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -255,7 +255,7 @@ fn decode_headers(headers: &[httparse::Header<'_>]) -> Result<usize, ParseError>
 #[cfg(test)]
 mod tests {
     use bytes::BytesMut;
-    use serde_json::Value;
+    use lsp_types::LSPAny;
 
     use super::*;
 
@@ -288,7 +288,7 @@ mod tests {
 
         let mut codec = LanguageServerCodec::default();
         let mut buffer = BytesMut::new();
-        let item: Value = serde_json::from_str(decoded).unwrap();
+        let item: LSPAny = serde_json::from_str(decoded).unwrap();
         codec.encode(item, &mut buffer).unwrap();
         assert_eq!(buffer, BytesMut::from(encoded.as_str()));
 
@@ -307,7 +307,7 @@ mod tests {
         let mut codec = LanguageServerCodec::default();
         let mut buffer = BytesMut::from(encoded.as_str());
         let message = codec.decode(&mut buffer).unwrap();
-        let decoded_: Value = serde_json::from_str(decoded).unwrap();
+        let decoded_: LSPAny = serde_json::from_str(decoded).unwrap();
         assert_eq!(message, Some(decoded_));
 
         let content_type = "application/vscode-jsonrpc; charset=utf8";
@@ -315,7 +315,7 @@ mod tests {
 
         let mut buffer = BytesMut::from(encoded.as_str());
         let message = codec.decode(&mut buffer).unwrap();
-        let decoded_: Value = serde_json::from_str(decoded).unwrap();
+        let decoded_: LSPAny = serde_json::from_str(decoded).unwrap();
         assert_eq!(message, Some(decoded_));
 
         let content_type = "application/vscode-jsonrpc; charset=invalid";
@@ -341,7 +341,7 @@ mod tests {
 
         let mut buffer = BytesMut::from(encoded.as_str());
         let message = codec.decode(&mut buffer).unwrap();
-        let decoded_: Value = serde_json::from_str(decoded).unwrap();
+        let decoded_: LSPAny = serde_json::from_str(decoded).unwrap();
         assert_eq!(message, Some(decoded_));
     }
 
@@ -352,7 +352,7 @@ mod tests {
 
         let mut codec = LanguageServerCodec::default();
         let mut buffer = BytesMut::from(encoded.as_str());
-        let message: Option<Value> = codec.decode(&mut buffer).unwrap();
+        let message: Option<LSPAny> = codec.decode(&mut buffer).unwrap();
         assert_eq!(message, None);
     }
 
@@ -369,7 +369,7 @@ mod tests {
             Err(ParseError::MissingContentLength)
         );
 
-        let message: Option<Value> = codec.decode(&mut buffer).unwrap();
+        let message: Option<LSPAny> = codec.decode(&mut buffer).unwrap();
         let first_valid = serde_json::from_str(decoded).unwrap();
         assert_eq!(message, Some(first_valid));
         assert_err!(
@@ -409,7 +409,7 @@ mod tests {
         assert_eq!(message, None);
         buffer.unsplit(rest);
 
-        let decoded: Value = serde_json::from_str(decoded).unwrap();
+        let decoded: LSPAny = serde_json::from_str(decoded).unwrap();
         let message = codec.decode(&mut buffer).unwrap();
         assert_eq!(message, Some(decoded));
     }

--- a/src/jsonrpc/error.rs
+++ b/src/jsonrpc/error.rs
@@ -3,8 +3,8 @@
 use std::borrow::Cow;
 use std::fmt::{self, Display, Formatter};
 
+use lsp_types::LSPAny;
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 
 /// A specialized [`Result`] error type for JSON-RPC handlers.
 ///
@@ -109,7 +109,7 @@ pub struct Error {
     pub message: Cow<'static, str>,
     /// Additional information about the error, if any.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub data: Option<Value>,
+    pub data: Option<LSPAny>,
 }
 
 impl Error {

--- a/src/jsonrpc/request.rs
+++ b/src/jsonrpc/request.rs
@@ -2,8 +2,8 @@ use std::borrow::Cow;
 use std::fmt::{self, Display, Formatter};
 use std::str::FromStr;
 
+use lsp_types::LSPAny;
 use serde::{Deserialize, Deserializer, Serialize};
-use serde_json::Value;
 
 use super::{Id, Version};
 
@@ -23,7 +23,7 @@ pub struct Request {
     method: Cow<'static, str>,
     #[serde(default, deserialize_with = "deserialize_some")]
     #[serde(skip_serializing_if = "Option::is_none")]
-    params: Option<Value>,
+    params: Option<LSPAny>,
     #[serde(default, deserialize_with = "deserialize_some")]
     #[serde(skip_serializing_if = "Option::is_none")]
     id: Option<Id>,
@@ -93,12 +93,12 @@ impl Request {
     }
 
     /// Returns the `params` field, if present.
-    pub fn params(&self) -> Option<&Value> {
+    pub fn params(&self) -> Option<&LSPAny> {
         self.params.as_ref()
     }
 
     /// Splits this request into the method name, request ID, and the `params` field, if present.
-    pub fn into_parts(self) -> (Cow<'static, str>, Option<Id>, Option<Value>) {
+    pub fn into_parts(self) -> (Cow<'static, str>, Option<Id>, Option<LSPAny>) {
         (self.method, self.id, self.params)
     }
 }
@@ -147,7 +147,7 @@ impl FromStr for Request {
 #[derive(Debug)]
 pub struct RequestBuilder {
     method: Cow<'static, str>,
-    params: Option<Value>,
+    params: Option<LSPAny>,
     id: Option<Id>,
 }
 
@@ -163,7 +163,7 @@ impl RequestBuilder {
     /// Sets the `params` member of the request to the given value.
     ///
     /// This member is omitted from the request by default.
-    pub fn params<V: Into<Value>>(mut self, params: V) -> Self {
+    pub fn params<V: Into<LSPAny>>(mut self, params: V) -> Self {
         self.params = Some(params.into());
         self
     }

--- a/src/jsonrpc/response.rs
+++ b/src/jsonrpc/response.rs
@@ -1,15 +1,15 @@
 use std::fmt::{self, Debug, Formatter};
 use std::str::FromStr;
 
+use lsp_types::LSPAny;
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 
 use super::{Error, Id, Result, Version};
 
 #[derive(Clone, PartialEq, Deserialize, Serialize)]
 #[serde(untagged)]
 enum Kind {
-    Ok { result: Value },
+    Ok { result: LSPAny },
     Err { error: Error },
 }
 
@@ -24,7 +24,7 @@ pub struct Response {
 
 impl Response {
     /// Creates a new successful response from a request ID and `Error` object.
-    pub const fn from_ok(id: Id, result: Value) -> Self {
+    pub const fn from_ok(id: Id, result: LSPAny) -> Self {
         Response {
             jsonrpc: Version,
             kind: Kind::Ok { result },
@@ -42,7 +42,7 @@ impl Response {
     }
 
     /// Creates a new response from a request ID and either an `Ok(Value)` or `Err(Error)` body.
-    pub fn from_parts(id: Id, body: Result<Value>) -> Self {
+    pub fn from_parts(id: Id, body: Result<LSPAny>) -> Self {
         match body {
             Ok(result) => Response::from_ok(id, result),
             Err(error) => Response::from_error(id, error),
@@ -51,7 +51,7 @@ impl Response {
 
     /// Splits the response into a request ID paired with either an `Ok(Value)` or `Err(Error)` to
     /// signify whether the response is a success or failure.
-    pub fn into_parts(self) -> (Id, Result<Value>) {
+    pub fn into_parts(self) -> (Id, Result<LSPAny>) {
         match self.kind {
             Kind::Ok { result } => (self.id, Ok(result)),
             Kind::Err { error } => (self.id, Err(error)),
@@ -71,7 +71,7 @@ impl Response {
     /// Returns the `result` value, if it exists.
     ///
     /// This member only exists if the response indicates success.
-    pub const fn result(&self) -> Option<&Value> {
+    pub const fn result(&self) -> Option<&LSPAny> {
         match &self.kind {
             Kind::Ok { result } => Some(result),
             _ => None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,6 @@ use lsp_types::request::{
     GotoImplementationResponse, GotoTypeDefinitionParams, GotoTypeDefinitionResponse,
 };
 use lsp_types::*;
-use serde_json::Value;
 use tower_lsp_macros::rpc;
 use tracing::{error, warn};
 
@@ -1323,7 +1322,7 @@ pub trait LanguageServer: Send + Sync + 'static {
     /// In most cases, the server creates a [`WorkspaceEdit`] structure and applies the changes to
     /// the workspace using `Client::apply_edit()` before returning from this function.
     #[rpc(name = "workspace/executeCommand")]
-    async fn execute_command(&self, params: ExecuteCommandParams) -> Result<Option<Value>> {
+    async fn execute_command(&self, params: ExecuteCommandParams) -> Result<Option<LSPAny>> {
         let _ = params;
         error!("Got a workspace/executeCommand request, but it is not implemented");
         Err(Error::method_not_found())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,8 @@
 #![deny(missing_docs)]
 #![forbid(unsafe_code)]
 
-pub extern crate lsp_types;
+/// A re-export of [`lsp-types`](https://docs.rs/lsp-types) for convenience.
+pub use lsp_types;
 
 /// A re-export of [`async-trait`](https://docs.rs/async-trait) for convenience.
 pub use async_trait::async_trait;

--- a/src/service.rs
+++ b/src/service.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 use futures::future::{self, BoxFuture, FutureExt};
-use serde_json::Value;
+use lsp_types::LSPAny;
 use tower::Service;
 
 use crate::jsonrpc::{
@@ -126,7 +126,7 @@ impl<S: LanguageServer> Service<Request> for LspService<S> {
             match response.as_ref().and_then(|res| res.error()) {
                 Some(Error {
                     code: ErrorCode::MethodNotFound,
-                    data: Some(Value::String(m)),
+                    data: Some(LSPAny::String(m)),
                     ..
                 }) if m.starts_with("$/") => Ok(None),
                 _ => Ok(response),

--- a/tower-lsp-macros/src/lib.rs
+++ b/tower-lsp-macros/src/lib.rs
@@ -148,7 +148,6 @@ fn gen_server_router(trait_name: &syn::Ident, methods: &[MethodCall]) -> proc_ma
             use lsp_types::*;
             use lsp_types::notification::*;
             use lsp_types::request::*;
-            use serde_json::Value;
 
             use super::#trait_name;
             use crate::jsonrpc::{Result, Router};


### PR DESCRIPTION
Using `serde_json::Value` without reexporting `serde_json` forces downstream users to add `serde_json` as a dependency. `LSPAny` is already present because we reexport `lsp_types` and is also more appropriate to the context 

Fixes #4

See original issue https://github.com/ebkalderon/tower-lsp/pull/407