### PR TITLE
chore(examples): remove needless default update

### DIFF
--- a/examples/custom_notification.rs
+++ b/examples/custom_notification.rs
@@ -44,7 +44,6 @@ impl LanguageServer for Backend {
                 }),
                 ..ServerCapabilities::default()
             },
-            ..Default::default()
         })
     }
 

--- a/examples/stdio.rs
+++ b/examples/stdio.rs
@@ -36,7 +36,6 @@ impl LanguageServer for Backend {
                 }),
                 ..ServerCapabilities::default()
             },
-            ..Default::default()
         })
     }
 

--- a/examples/tcp.rs
+++ b/examples/tcp.rs
@@ -37,7 +37,6 @@ impl LanguageServer for Backend {
                 }),
                 ..ServerCapabilities::default()
             },
-            ..Default::default()
         })
     }
 

--- a/examples/websocket.rs
+++ b/examples/websocket.rs
@@ -38,7 +38,6 @@ impl LanguageServer for Backend {
                 }),
                 ..ServerCapabilities::default()
             },
-            ..Default::default()
         })
     }
 


### PR DESCRIPTION
There are 4 clippy lints left in the examples.

As @idealseal pointed out in https://github.com/tower-lsp/tower-lsp/pull/10, these are needed to make the code work when using the `proposed` feature. Still, it would be great to get rid of them.

I am not sure whether we should
- ignore them: makes noises when linting examples
- delete them: makes examples not compile when using `proposed` feature. Maybe this is OK because at this point, users know the lib and understand what to do next.
- silence the lint: works but silences the lint