### PR TITLE
feat: use async-fn-in-trait syntax

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,15 +8,18 @@ on:
     branches:
     - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   cargo-test:
     name: cargo test ${{ matrix.os }}-${{ matrix.rust-version }}-${{ matrix.runtime }})
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        rust-version: [1.82.0, 1.70.0, nightly]
+        rust-version: [1.82.0, 1.77.0, nightly]
         runtime: [runtime-tokio, runtime-agnostic]
 
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,17 +40,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-trait"
-version = "0.1.83"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "async-tungstenite"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -74,17 +63,6 @@ dependencies = [
  "pharos",
  "rustc_version",
  "tokio",
-]
-
-[[package]]
-name = "auto_impl"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c87f3f15e7794432337fc718554eaa4dc8f04c9677a950ffe366f20a162ae42"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -802,9 +780,7 @@ name = "tower-lsp-server"
 version = "0.21.0"
 dependencies = [
  "async-codec-lite",
- "async-trait",
  "async-tungstenite",
- "auto_impl",
  "bytes",
  "dashmap",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 categories = ["asynchronous"]
 keywords = ["language-server", "lsp", "tower"]
 exclude = ["FEATURES.md"]
-rust-version = "1.70"
+rust-version = "1.77"
 
 [features]
 default = ["runtime-tokio"]
@@ -24,8 +24,6 @@ proposed = ["lsp-types/proposed"]
 tower-lsp-server-macros = { version = "0.9", path = "./tower-lsp-server-macros" }
 
 async-codec-lite = { version = "0.0", optional = true }
-async-trait = "0.1"
-auto_impl = "1"
 bytes = "1"
 dashmap = "6"
 futures = { version = "0.3", default-features = false, features = ["std", "async-await"] }

--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ struct Backend {
     client: Client,
 }
 
-#[tower_lsp_server::async_trait]
 impl LanguageServer for Backend {
     async fn initialize(&self, _: InitializeParams) -> Result<InitializeResult> {
         Ok(InitializeResult::default())

--- a/examples/custom_notification.rs
+++ b/examples/custom_notification.rs
@@ -32,7 +32,6 @@ struct Backend {
     client: Client,
 }
 
-#[tower_lsp_server::async_trait]
 impl LanguageServer for Backend {
     async fn initialize(&self, _: InitializeParams) -> Result<InitializeResult> {
         Ok(InitializeResult {

--- a/examples/stdio.rs
+++ b/examples/stdio.rs
@@ -7,7 +7,6 @@ struct Backend {
     client: Client,
 }
 
-#[tower_lsp_server::async_trait]
 impl LanguageServer for Backend {
     async fn initialize(&self, _: InitializeParams) -> Result<InitializeResult> {
         Ok(InitializeResult {

--- a/examples/tcp.rs
+++ b/examples/tcp.rs
@@ -8,7 +8,6 @@ struct Backend {
     client: Client,
 }
 
-#[tower_lsp_server::async_trait]
 impl LanguageServer for Backend {
     async fn initialize(&self, _: InitializeParams) -> Result<InitializeResult> {
         Ok(InitializeResult {

--- a/examples/websocket.rs
+++ b/examples/websocket.rs
@@ -11,7 +11,6 @@ struct Backend {
     client: Client,
 }
 
-#[tower_lsp_server::async_trait]
 impl LanguageServer for Backend {
     async fn initialize(&self, _: InitializeParams) -> Result<InitializeResult> {
         Ok(InitializeResult {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,6 @@
 //!     client: Client,
 //! }
 //!
-//! #[tower_lsp_server::async_trait]
 //! impl LanguageServer for Backend {
 //!     async fn initialize(&self, _: InitializeParams) -> Result<InitializeResult> {
 //!         Ok(InitializeResult {
@@ -80,16 +79,12 @@
 /// A re-export of [`lsp-types`](https://docs.rs/lsp-types) for convenience.
 pub use lsp_types;
 
-/// A re-export of [`async-trait`](https://docs.rs/async-trait) for convenience.
-pub use async_trait::async_trait;
-
 pub use self::service::progress::{
     Bounded, Cancellable, NotCancellable, OngoingProgress, Progress, Unbounded,
 };
 pub use self::service::{Client, ClientSocket, ExitedError, LspService, LspServiceBuilder};
 pub use self::transport::{Loopback, Server};
 
-use auto_impl::auto_impl;
 use lsp_types::request::{
     GotoDeclarationParams, GotoDeclarationResponse, GotoImplementationParams,
     GotoImplementationResponse, GotoTypeDefinitionParams, GotoTypeDefinitionResponse,
@@ -113,8 +108,6 @@ mod transport;
 ///
 /// [Language Server Protocol]: https://microsoft.github.io/language-server-protocol/
 #[rpc]
-#[async_trait]
-#[auto_impl(Arc, Box)]
 pub trait LanguageServer: Send + Sync + 'static {
     /// The [`initialize`] request is the first request sent from the client to the server.
     ///
@@ -1373,9 +1366,4 @@ pub trait LanguageServer: Send + Sync + 'static {
 
     // TODO: Add `work_done_progress_cancel()` here (since 3.15.0) when supported by `tower-lsp-server`
     // https://github.com/ebkalderon/tower-lsp/issues/176
-}
-
-fn _assert_object_safe() {
-    fn assert_impl<T: LanguageServer>() {}
-    assert_impl::<Box<dyn LanguageServer>>();
 }

--- a/src/service.rs
+++ b/src/service.rs
@@ -176,7 +176,6 @@ impl<S: LanguageServer> LspServiceBuilder<S> {
     /// struct Mock;
     ///
     /// // Implementation of `LanguageServer` omitted...
-    /// # #[tower_lsp_server::async_trait]
     /// # impl LanguageServer for Mock {
     /// #     async fn initialize(&self, _: InitializeParams) -> Result<InitializeResult> {
     /// #         Ok(InitializeResult::default())
@@ -248,7 +247,6 @@ impl<S: Debug> Debug for LspServiceBuilder<S> {
 
 #[cfg(test)]
 mod tests {
-    use async_trait::async_trait;
     use lsp_types::*;
     use serde_json::json;
     use tower::ServiceExt;
@@ -259,7 +257,6 @@ mod tests {
     #[derive(Debug)]
     struct Mock;
 
-    #[async_trait]
     impl LanguageServer for Mock {
         async fn initialize(&self, _: InitializeParams) -> Result<InitializeResult> {
             Ok(InitializeResult::default())

--- a/tower-lsp-server-macros/Cargo.toml
+++ b/tower-lsp-server-macros/Cargo.toml
@@ -15,4 +15,4 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1"
 quote = "1"
-syn = { version = "2", features = ["full"] }
+syn = { version = "2", default-features = false }


### PR DESCRIPTION
Closes #28

To reiterate, this is a breaking change in the public API where the signature of `LanguageServer` methods are updated in this manner:

```rust
// before
fn initialized<'this, 'async_trait>(&'this self) -> Pin<Box<dyn Future<Output = ()> + Send + 'async_trait>>
where
    Self: 'async_trait,
    'this: 'async_trait;

// after
fn initialized(&self) -> impl Future<Output = ()> + Send;
```

Documentation will likely need to be updated with a migration guide for this change.