### PR TITLE
Symbol can return WorkspaceSymbol

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -1218,7 +1218,7 @@ rpc! {
         async fn symbol(
             &self,
             params: WorkspaceSymbolParams,
-        ) -> Result<Option<Vec<SymbolInformation>>> {
+        ) -> Result<Option<OneOf<Vec<SymbolInformation>, Vec<WorkspaceSymbol>>>> {
             let _ = params;
             error!("got a `workspace/symbol` request, but it is not implemented");
             Err(Error::method_not_found())


### PR DESCRIPTION
According to the specification [workspace/symbol](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_symbol) can return:
> SymbolInformation[] | WorkspaceSymbol[] | null. See above for the definition of [SymbolInformation](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#symbolInformation). It is recommended that you use the new [WorkspaceSymbol](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspaceSymbol). However whether the workspace symbol can return a location without a range depends on the client capability workspace.symbol.resolveSupport.