### PR TITLE
docs: add pytest-language-server to projects using tower-lsp-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ You can use enable proposed features in the [LSP Specification version 3.18](htt
 - [Turborepo](https://github.com/vercel/turborepo/tree/main/crates/turborepo-lsp) (still uses the original project)
 - [Veryl](https://github.com/veryl-lang/veryl)
 - [django-language-server](https://github.com/joshuadavidthomas/django-language-server)
+- [pytest-language-server](https://github.com/bellini666/pytest-language-server)
 - [SystemD-LSP](https://github.com/JFryy/systemd-lsp)
 - [Amber LSP](https://github.com/amber-lang/amber-lsp)
 


### PR DESCRIPTION
Adding https://github.com/bellini666/pytest-language-server to the list of LSP servers
