### PR TITLE
fix(deps): switch from futures to futures_util and futures_channel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,20 +146,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -210,7 +196,6 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
- "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -697,7 +682,8 @@ dependencies = [
  "async-tungstenite",
  "bytes",
  "dashmap",
- "futures",
+ "futures-channel",
+ "futures-util",
  "httparse",
  "ls-types",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,8 @@ proposed = ["ls-types/proposed"]
 async-codec-lite = { version = "0.0", optional = true }
 bytes = "1"
 dashmap = "6"
-futures = { version = "0.3", default-features = false, features = ["std", "async-await"] }
+futures-util = { version = "0.3", default-features = false, features = [ "std", "async-await", "io", "async-await-macro", "sink" ] }
+futures-channel = { version = "0.3", features = ["sink"] }
 httparse = "1"
 ls-types = "0.0"
 memchr = "2"

--- a/src/jsonrpc/router.rs
+++ b/src/jsonrpc/router.rs
@@ -8,7 +8,7 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
-use futures::future::{self, BoxFuture, FutureExt};
+use futures_util::future::{self, BoxFuture, FutureExt};
 use ls_types::LSPAny;
 use serde::{Serialize, de::DeserializeOwned};
 use tower::{Layer, Service, util::BoxService};

--- a/src/service.rs
+++ b/src/service.rs
@@ -9,7 +9,7 @@ use std::fmt::{self, Debug, Display, Formatter};
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
-use futures::future::{self, BoxFuture, FutureExt};
+use futures_util::future::{self, BoxFuture, FutureExt};
 use ls_types::LSPAny;
 use tower::Service;
 
@@ -356,7 +356,7 @@ mod tests {
 
         let pending_fut = service.ready().await.unwrap().call(pending_request);
         let cancel_fut = service.ready().await.unwrap().call(cancel_request);
-        let (pending_response, cancel_response) = futures::join!(pending_fut, cancel_fut);
+        let (pending_response, cancel_response) = futures_util::join!(pending_fut, cancel_fut);
 
         let canceled = Response::from_error(1.into(), Error::request_cancelled());
         assert_eq!(pending_response, Ok(Some(canceled)));

--- a/src/service/client.rs
+++ b/src/service/client.rs
@@ -11,11 +11,8 @@ use std::{
     task::{Context, Poll},
 };
 
-use futures::{
-    channel::mpsc::{self, Sender},
-    future::BoxFuture,
-    sink::SinkExt,
-};
+use futures_channel::mpsc::{self, Sender};
+use futures_util::{future::BoxFuture, sink::SinkExt};
 use ls_types::{notification, request, *};
 use serde::Serialize;
 use tower::Service;
@@ -709,7 +706,7 @@ impl Service<Request> for Client {
 mod tests {
     use std::future::Future;
 
-    use futures::stream::StreamExt;
+    use futures_util::stream::StreamExt;
     use ls_types::notification::{LogMessage, PublishDiagnostics, ShowMessage, TelemetryEvent};
     use serde_json::json;
 

--- a/src/service/client/pending.rs
+++ b/src/service/client/pending.rs
@@ -4,7 +4,7 @@ use std::fmt::{self, Debug, Formatter};
 use std::future::Future;
 
 use dashmap::{DashMap, mapref::entry::Entry};
-use futures::channel::oneshot;
+use futures_channel::oneshot;
 use tracing::warn;
 
 use crate::jsonrpc::{Id, Response};

--- a/src/service/client/socket.rs
+++ b/src/service/client/socket.rs
@@ -4,9 +4,9 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
-use futures::channel::mpsc::Receiver;
-use futures::sink::Sink;
-use futures::stream::{FusedStream, Stream, StreamExt};
+use futures_channel::mpsc::Receiver;
+use futures_util::sink::Sink;
+use futures_util::stream::{FusedStream, Stream, StreamExt};
 
 use super::{ExitedError, Pending, ServerState, State};
 use crate::jsonrpc::{Request, Response};
@@ -24,8 +24,8 @@ impl ClientSocket {
     ///
     /// The two halves returned implement the [`Stream`] and [`Sink`] traits, respectively.
     ///
-    /// [`Stream`]: futures::Stream
-    /// [`Sink`]: futures::Sink
+    /// [`Stream`]: futures_util::Stream
+    /// [`Sink`]: futures_util::Sink
     pub fn split(self) -> (RequestStream, ResponseSink) {
         let Self { rx, pending, state } = self;
         let state_ = state.clone();

--- a/src/service/layers.rs
+++ b/src/service/layers.rs
@@ -4,7 +4,7 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
-use futures::future::{self, BoxFuture, FutureExt};
+use futures_util::future::{self, BoxFuture, FutureExt};
 use tower::{Layer, Service};
 use tracing::{info, warn};
 

--- a/src/service/pending.rs
+++ b/src/service/pending.rs
@@ -5,7 +5,7 @@ use std::future::Future;
 use std::sync::Arc;
 
 use dashmap::{DashMap, mapref::entry::Entry};
-use futures::future::{self, Either};
+use futures_util::future::{self, Either};
 use tracing::{debug, info};
 
 use super::ExitedError;

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -3,15 +3,15 @@
 #[cfg(feature = "runtime-agnostic")]
 use async_codec_lite::{FramedRead, FramedWrite};
 #[cfg(feature = "runtime-agnostic")]
-use futures::io::{AsyncRead, AsyncWrite};
+use futures_util::io::{AsyncRead, AsyncWrite};
 
 #[cfg(feature = "runtime-tokio")]
 use tokio::io::{AsyncRead, AsyncWrite};
 #[cfg(feature = "runtime-tokio")]
 use tokio_util::codec::{FramedRead, FramedWrite};
 
-use futures::channel::mpsc;
-use futures::{
+use futures_channel::mpsc;
+use futures_util::{
     FutureExt, Sink, SinkExt, Stream, StreamExt, TryFutureExt, future, join, stream, stream_select,
 };
 use tower::Service;
@@ -206,12 +206,12 @@ mod tests {
     use std::task::{Context, Poll};
 
     #[cfg(feature = "runtime-agnostic")]
-    use futures::io::Cursor;
+    use futures_util::io::Cursor;
     #[cfg(feature = "runtime-tokio")]
     use std::io::Cursor;
 
-    use futures::future::Ready;
-    use futures::{future, sink, stream};
+    use futures_util::future::Ready;
+    use futures_util::{future, sink, stream};
 
     use super::*;
 


### PR DESCRIPTION
# Motivation
Reduce the dependency surface by only using a subset of the `futures` crates.
We are currently using this lib for a wasm module and we would benefit from this to avoid having too heavy wasm modules.