### PR TITLE
Add textDocument/inlineCompletion (LSP 3.18)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 [Unreleased]: https://github.com/tower-lsp-community/tower-lsp-server/compare/v0.22.1...HEAD
 
+### Added
+
+- Add support for `textDocument/inlineCompletion` from LSP 3.18.0.
+
 ## [0.23.0] - 2025-12-07
 
 ### Added

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -32,7 +32,25 @@ Symbol          | Description
 
 </details>
 
-### Overall status: (84.5/90) _~93%_
+### Overall status: (85.5/95) _~90%_
+
+## [3.18.0] - 2026-06-04
+
+### Status: (1/5)
+
+Method Name                                | Message Type                | Supported      | Tracking Issue(s)
+-------------------------------------------|:---------------------------:|:--------------:|------------------
+[`textDocument/inlineCompletion`]          | :leftwards_arrow_with_hook: | :green_circle: |
+[`workspace/textDocumentContent`]          | :leftwards_arrow_with_hook: | :red_circle:   |
+[`workspace/textDocumentContent/refresh`]  | :arrow_right_hook:          | :red_circle:   |
+[`workspace/foldingRange/refresh`]         | :arrow_right_hook:          | :red_circle:   |
+[`textDocument/rangesFormatting`]          | :leftwards_arrow_with_hook: | :red_circle:   |
+
+[`textDocument/inlineCompletion`]: https://microsoft.github.io/language-server-protocol/specification#textDocument_inlineCompletion
+[`workspace/textDocumentContent`]: https://microsoft.github.io/language-server-protocol/specification#workspace_textDocumentContent
+[`workspace/textDocumentContent/refresh`]: https://microsoft.github.io/language-server-protocol/specification#workspace_textDocumentContentRefresh
+[`workspace/foldingRange/refresh`]: https://microsoft.github.io/language-server-protocol/specification#workspace_foldingRange_refresh
+[`textDocument/rangesFormatting`]: https://microsoft.github.io/language-server-protocol/specification#textDocument_rangeFormatting
 
 ## [3.17.0] - 2022-05-10
 
@@ -312,6 +330,7 @@ Method Name                          | Message Type                | Supported  
 [o#145]: https://github.com/ebkalderon/tower-lsp/issues/145
 [o#231]: https://github.com/ebkalderon/tower-lsp/issues/231
 
+[3.18.0]: https://microsoft.github.io/language-server-protocol/specification#version_3_18_0
 [3.17.0]: https://microsoft.github.io/language-server-protocol/specification#version_3_17_0
 [3.16.0]: https://microsoft.github.io/language-server-protocol/specification#version_3_16_0
 [3.15.0]: https://microsoft.github.io/language-server-protocol/specification#version_3_15_0

--- a/src/server.rs
+++ b/src/server.rs
@@ -906,6 +906,29 @@ rpc! {
             Err(Error::method_not_found())
         }
 
+        /// The [`textDocument/inlineCompletion`] request is sent from the client to the server to
+        /// compute inline completions for a given text document, either explicitly by a user gesture
+        /// or implicitly when typing.
+        ///
+        /// Inline completion items usually complete larger portions of text (for example whole
+        /// methods) and, in contrast to completions, may complete code that is syntactically or
+        /// semantically incorrect.
+        ///
+        /// [`textDocument/inlineCompletion`]: https://microsoft.github.io/language-server-protocol/specification#textDocument_inlineCompletion
+        ///
+        /// # Compatibility
+        ///
+        /// This request was introduced in specification version 3.18.0.
+        #[rpc(name = "textDocument/inlineCompletion")]
+        async fn inline_completion(
+            &self,
+            params: InlineCompletionParams,
+        ) -> Result<Option<InlineCompletionResponse>> {
+            let _ = params;
+            error!("got a `textDocument/inlineCompletion` request, but it is not implemented");
+            Err(Error::method_not_found())
+        }
+
         /// The [`textDocument/diagnostic`] request is sent from the client to the server to ask the
         /// server to compute the diagnostics for a given document.
         ///


### PR DESCRIPTION
Hi,

I added the feature table for LSP 3.18 and a default handler for the new textDocument/inlineCompletion. 
The default handler returns `method_not_found`, matching the other unimplemented language-feature stubs.

I'd be happy to follow up with more LSP 3.18 support as well. A few of the remaining methods appear blocked on missing types in `ls-types` right now, for example `DocumentRangesFormattingParams` for `textDocument/rangesFormatting` (as opposed to the existing singular `DocumentRangeFormattingParams` / `textDocument/rangeFormatting`).

I could also implement those on top of the `gen-lsp-types` migration PR once that lands, since those types are already available there.